### PR TITLE
fix:Only document could trigger scroll event but not document.documen…

### DIFF
--- a/packages/scroll-position/src/__tests__/index.test.js
+++ b/packages/scroll-position/src/__tests__/index.test.js
@@ -39,6 +39,20 @@ describe('useScrollPosition', () => {
         document.documentElement.scrollLeft = 0;
     });
 
+    test('window scroll change', async () => {
+        const {result, waitForNextUpdate} = renderHook(() => useScrollPosition());
+        expect(result.current.x).toBe(0);
+        expect(result.current.y).toBe(0);
+        document.documentElement.scrollTop = 20;
+        document.documentElement.scrollLeft = 30;
+        document.dispatchEvent(new Event('scroll'));
+        await waitForNextUpdate();
+        expect(result.current.x).toBe(30);
+        expect(result.current.y).toBe(20);
+        document.documentElement.scrollTop = 0;
+        document.documentElement.scrollLeft = 0;
+    });
+
     test('change element', () => {
         const div = document.createElement('div');
         const span = document.createElement('div');

--- a/packages/scroll-position/src/index.ts
+++ b/packages/scroll-position/src/index.ts
@@ -37,8 +37,8 @@ export function useScrollPosition(element?: HTMLElement | null): ScrollPosition 
                 return;
             }
 
-            const target = element === undefined ? document : element;
-            const targetElement = element === undefined ? document.documentElement : element;
+            const target = element ?? document;
+            const targetElement = element ?? document.documentElement;
 
             setPosition(getScrollPosition(targetElement));
 

--- a/packages/scroll-position/src/index.ts
+++ b/packages/scroll-position/src/index.ts
@@ -37,9 +37,10 @@ export function useScrollPosition(element?: HTMLElement | null): ScrollPosition 
                 return;
             }
 
-            const target = element === undefined ? document.documentElement : element;
+            const target = element === undefined ? document : element;
+            const targetElement = element === undefined ? document.documentElement : element;
 
-            setPosition(getScrollPosition(target));
+            setPosition(getScrollPosition(targetElement));
 
             const syncScroll = () => {
                 if (rafTick.current) {
@@ -47,7 +48,7 @@ export function useScrollPosition(element?: HTMLElement | null): ScrollPosition 
                 }
 
                 const callback = () => {
-                    setPosition(getScrollPosition(target));
+                    setPosition(getScrollPosition(targetElement));
                     rafTick.current = 0;
                 };
                 rafTick.current = requestAnimationFrame(callback);


### PR DESCRIPTION
OS: Mac@10.13.2
Browser: Chrome@80.0.3987.132（正式版本） （64 位）

测试发现当窗口滚动时候，只有 `document` 能捕获到 `scroll` 事件，`document.documentElement` 无法捕获。这个写单测不知道咋写，`window.scrollTo` 不能用，可以在这里看 [demo](https://jsbin.com/qahuped/edit?html,css,js,console,output)，点击【执行】或者滚动窗口即可