### PR TITLE
fix(useInfiniteScroll): fetch unexpected called twice.

### DIFF
--- a/packages/infinite-scroll/src/__tests__/index.test.js
+++ b/packages/infinite-scroll/src/__tests__/index.test.js
@@ -29,6 +29,17 @@ test('initial load', async () => {
     expect(result.current.dataSource).toEqual([1, 2, 3]);
 });
 
+test('initial load with loadMore called when loading', async () => {
+    const fetch = jest.fn(values);
+    const {result, waitForNextUpdate} = renderHook(() => useInfiniteScroll(fetch, {initialLoad: true}));
+    await act(() => result.current.loadMore());
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith({offset: 0});
+    expect(result.current.hasMore).toBe(true);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.dataSource).toEqual([1, 2, 3]);
+});
+
 test('load more', async () => {
     const fetch = jest.fn(values);
     const {result} = renderHook(() => useInfiniteScroll(fetch));

--- a/packages/infinite-scroll/src/index.ts
+++ b/packages/infinite-scroll/src/index.ts
@@ -55,15 +55,19 @@ export function useInfiniteScroll<T>(
         createContextReducers<T>(),
         {pendingCount: 0, dataSource: initialItems, hasMore: true}
     );
+    const loading = !!pendingCount;
     const loadMore = useCallback(
         async () => {
+            if (loading) {
+                return;
+            }
             initialLoadStarted.current = true;
             requestStart();
             const response = await fetch({offset: dataSource.length});
             initialLoadEnded.current = true;
             requestEnd(response);
         },
-        [requestStart, fetch, dataSource.length, requestEnd]
+        [loading, requestStart, fetch, dataSource.length, requestEnd]
     );
     useEffect(
         () => {
@@ -78,7 +82,7 @@ export function useInfiniteScroll<T>(
         dataSource,
         loadMore,
         hasMore,
-        loading: !!pendingCount,
-        initialLoading: initialLoad && !initialLoadEnded.current && !!pendingCount,
+        loading,
+        initialLoading: initialLoad && !initialLoadEnded.current && loading,
     };
 }


### PR DESCRIPTION
When initialLoad is true, and loadMore was called when initialLoad is pending,
the fetch function will be called twice with the same offset,
and the result data will be duplicated.

This commit fix this issue to ensure fetch fucntion only called once and
the result data are all unique.

Close #31 