### PR TITLE
Fix useArray incorrectly use immer for filter

### DIFF
--- a/packages/collection/src/__tests__/array.test.js
+++ b/packages/collection/src/__tests__/array.test.js
@@ -81,6 +81,11 @@ test('splice', () => {
 
 test('remove', () => {
     testFunction(m => m.remove(2), [1, 3, 4, 1, 3, 4]);
+    testFunction(m => m.remove(10), [1, 2, 3, 4, 1, 2, 3, 4]);
+    const objectArray = [{}, {}, {}];
+    const {result} = renderHook(() => useArray(objectArray));
+    act(() => result.current[1].remove(objectArray[1]));
+    expect(result.current[0].length).toBe(2);
 });
 
 test('removeAt', () => {

--- a/packages/collection/src/array.ts
+++ b/packages/collection/src/array.ts
@@ -1,37 +1,53 @@
-import {useMethods} from '@huse/methods';
+import {useMethodsNative} from '@huse/methods';
 
 function createMethods<T>() {
     return {
         push(state: T[], item: T) {
-            state.push(item);
+            return [...state, item];
         },
         unshift(state: T[], item: T) {
-            state.unshift(item);
+            return [item, ...state];
         },
         pop(state: T[]) {
-            if (state.length !== 0) {
-                state.splice(state.length - 1, 1);
+            if (!state.length) {
+                return state;
             }
+
+            return state.slice(0, -1);
         },
         shift(state: T[]) {
-            if (state.length !== 0) {
-                state.splice(0, 1);
+            if (!state.length) {
+                return state;
             }
+
+            return state.slice(1);
         },
         slice(state: T[], start?: number, end?: number) {
             return state.slice(start, end);
         },
         splice(state: T[], index: number, deleteCount: number, ...insertions: T[]) {
-            state.splice(index, deleteCount, ...insertions);
+            return [
+                ...state.slice(0, index),
+                ...insertions,
+                ...state.slice(index + deleteCount),
+            ];
         },
         remove(state: T[], item: T) {
-            return state.filter(v => v !== item);
+            const next = state.filter(v => v !== item);
+            return state.length === next.length ? state : next;
         },
         removeAt(state: T[], index: number) {
-            state.splice(index, 1);
+            return [
+                ...state.slice(0, index),
+                ...state.slice(index + 1),
+            ];
         },
         insertAt(state: T[], index: number, item: T) {
-            state.splice(index, 0, item);
+            return [
+                ...state.slice(0, index),
+                item,
+                ...state.slice(index),
+            ];
         },
         concat(state: T[], item: T | T[]) {
             return state.concat(item);
@@ -39,15 +55,24 @@ function createMethods<T>() {
         replace(state: T[], from: T, to: T) {
             const index = state.indexOf(from);
             if (index >= 0) {
-                state.splice(index, 1, to);
+                return [
+                    ...state.slice(0, index),
+                    to,
+                    ...state.slice(index + 1),
+                ];
             }
+            return state;
         },
         replaceAll(state: T[], from: T, to: T) {
             const has = state.includes(from);
             return has ? state.map(v => (v === from ? to : v)) : state;
         },
         replaceAt(state: T[], index: number, item: T) {
-            state.splice(index, 1, item);
+            return [
+                ...state.slice(0, index),
+                item,
+                ...state.slice(index + 1),
+            ];
         },
         filter(state: T[], predicate: (item: T, index: number) => boolean) {
             return state.filter(predicate);
@@ -76,5 +101,5 @@ function createMethods<T>() {
 }
 
 export default function useArray<T>(initialValue: T[] = []) {
-    return useMethods(createMethods<T>(), initialValue);
+    return useMethodsNative(createMethods<T>(), initialValue);
 }


### PR DESCRIPTION
Seems `immer` wraps all objects breaking reference equality check

https://github.com/ecomfe/react-hooks/issues/40#issuecomment-747909647