### PR TITLE
fix(debounce): callback params

### DIFF
--- a/packages/debounce/src/index.ts
+++ b/packages/debounce/src/index.ts
@@ -88,7 +88,11 @@ export function useDebouncedValue<T>(value: T, wait: number, option?: DebounceOp
  * @param wait {Number} timeout in ms (`100`)
  * @param option.immediate {Boolean} whether to execute at the beginning (`false`)
  */
-export function useDebouncedCallback<C extends() => any>(callback: C, wait: number, option: DebounceOption = {}): C {
+export function useDebouncedCallback<C extends (...args: any) => any>(
+    callback: C,
+    wait: number,
+    option: DebounceOption = {}
+): C {
     const {immediate} = option;
     const debouncedCallback = useMemo(
         () => (wait > 0 ? debounce(callback, wait, immediate) : callback),

--- a/packages/debounce/src/index.ts
+++ b/packages/debounce/src/index.ts
@@ -88,7 +88,7 @@ export function useDebouncedValue<T>(value: T, wait: number, option?: DebounceOp
  * @param wait {Number} timeout in ms (`100`)
  * @param option.immediate {Boolean} whether to execute at the beginning (`false`)
  */
-export function useDebouncedCallback<C extends (...args: any) => any>(
+export function useDebouncedCallback<C extends(...args: any) => any>(
     callback: C,
     wait: number,
     option: DebounceOption = {}


### PR DESCRIPTION
`useDebouncedCallback`可能与`useCallback`是类似的，返回一个带防抖的函数

`() => any`指没有参数的函数，继承于此可能会阻塞带参数的回调函数

如果是设计如此，我会 close 这个提交